### PR TITLE
Fix circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,22 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm install
-            - run: npm test
-            - run: npx chromatic --project-token=gpeep2z0kqd
-            - run: |
-                if [ $CIRCLE_BRANCH = "master" ]
-                then
-                  npm run release
-                fi
+            - run:
+                name: Install dependencies
+                command: npm install
+            
+            - run:
+                name: Run tests
+                command: npm test
+            
+            - run:
+                name: Deploy package
+                command: |
+                  if [ $CIRCLE_BRANCH = "master" -a -n "$CHROMATIC_PROJECT_TOKEN" ]
+                  then
+                    npx chromatic --project-token="$CHROMATIC_PROJECT_TOKEN"
+                    npm run release
+                  fi
 workflows:
   build-and-test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ jobs:
             - run: npm install
             - run: npm test
             - run: npx chromatic --project-token=gpeep2z0kqd
-            # - run: |
-            #     if [ $CIRCLE_BRANCH = "master" ]
-            #     then
-            #       npm release
-            #     fi
+            - run: |
+                if [ $CIRCLE_BRANCH = "master" ]
+                then
+                  npm run release
+                fi
 workflows:
   build-and-test:
     jobs:


### PR DESCRIPTION
Fixes the failing build and removes the hardcoded token.
Also has minor improvements to the CI config.

Please add a (regenerated) chromatic project token as a CircleCI Environment Variable named `CHROMATIC_PROJECT_TOKEN`
CircleCI Docs: [Setting an Environment Variable in a Project](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)

If possible, please also revoke the old token (`gpeep2z0kqd`).

Closes #16 