### PR TITLE
 Improving Typography component test coverage to 97%.

### DIFF
--- a/src/components/typography/Typography.test.js
+++ b/src/components/typography/Typography.test.js
@@ -6,22 +6,44 @@ import { Typography } from "./Typography";
 
 let container = null;
 beforeEach(() => {
-    // setting up DOM element as render target
-    container = document.createElement("div");
-    document.body.appendChild(container);
+  // setting up DOM element as render target
+  container = document.createElement("div");
+  document.body.appendChild(container);
 });
 
 afterEach(() => {
-    // cleanup on exiting
-    unmountComponentAtNode(container);
-    container.remove();
-    container = null;
+  // cleanup on exiting
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
 });
 
+const variantValue = [
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "subtitle1",
+  "subtitle2",
+  "body1",
+  "body2",
+];
+
+// Using each statement https://jestjs.io/docs/en/api#describeeachtablename-fn-timeout
 // tests whether child content is rendered
-it("renders typography label", () => {
-    act(() => {
-        render(<Typography variant="h2">Test</Typography>, container);
-    });
-    expect(container.textContent).toBe("Test");
+describe("typography component testing", () => {
+  test.each(variantValue)(
+    "test Typography with %p as variant props",
+    (typo) => {
+      act(() => {
+        render(
+          <Typography variant={typo}>{"Test " + typo}</Typography>,
+          container
+        );
+      });
+      expect(container.textContent).toBe("Test " + typo);
+    }
+  );
 });


### PR DESCRIPTION
I made this PR for make the `Typography.test.js` test suit treats all possible case, rather then testing with one possible variant case. it improved the test coverage from 45% to 97%.
cc/ @daniel-norris .

### **Before:**
![screencapture-localhost-5500-coverage-lcov-report-typography-index-html-2020-10-20-03_46_49](https://user-images.githubusercontent.com/29590613/96534035-e281b100-1286-11eb-851e-feec7471e7ec.png)
### **After:**
![screencapture-localhost-5500-coverage-lcov-report-typography-index-html-2020-10-20-03_50_52](https://user-images.githubusercontent.com/29590613/96534085-f5948100-1286-11eb-9c40-20a361d9b733.png)
